### PR TITLE
Add loading spinner to slice button

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -67,10 +67,45 @@ body {
   font-weight: 600;
 }
 
+.field-row button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-width: 100px;
+}
+
 .field-row button:disabled,
 .segment-footer button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.button-spinner {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 50%;
+  border: 2px solid rgba(248, 250, 252, 0.4);
+  border-top-color: #f8fafc;
+  animation: button-spin 0.75s linear infinite;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes button-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .error-message {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -504,7 +504,14 @@ function App() {
               disabled={loading}
             />
             <button type="submit" disabled={loading}>
-              {loading ? "Processing..." : "Slice"}
+              {loading ? (
+                <>
+                  <span className="button-spinner" aria-hidden="true" />
+                  <span className="visually-hidden">Processing</span>
+                </>
+              ) : (
+                "Slice"
+              )}
             </button>
           </div>
         </form>


### PR DESCRIPTION
## Summary
- replace the "Processing..." label with a compact spinner icon
- add supporting styles so the button layout stays within the frame

## Testing
- npm run lint