### PR TITLE
Tighten slice button layout for spinner

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -72,7 +72,12 @@ body {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  min-width: 100px;
+  min-width: 110px;
+  min-height: 42px;
+  padding: 0 1.25rem;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  line-height: 1;
 }
 
 .field-row button:disabled,
@@ -82,8 +87,8 @@ body {
 }
 
 .button-spinner {
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 1rem;
+  height: 1rem;
   border-radius: 50%;
   border: 2px solid rgba(248, 250, 252, 0.4);
   border-top-color: #f8fafc;


### PR DESCRIPTION
## Summary
- prevent the slice button from shrinking when the spinner appears by fixing its dimensions
- trim spinner size so it stays centered without clipping

## Testing
- npm run lint