### PR TITLE
Fix sidebar segments list to display all segments

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -191,7 +191,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  max-height: 240px;
+  max-height: 60vh;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- Fixed sidebar segments list height to show all segments for long articles
- Changed `max-height` from `240px` to `60vh` for better scalability

## Problem
Articles with many sections (e.g., the AI Native Software Engineer article with 46 segments) were only showing ~5 segments in the lateral menu due to a fixed 240px height limit.

## Solution
Updated `.segments-list` CSS to use `60vh` instead of `240px`, allowing the list to scale with viewport height while remaining scrollable.

## Test Plan
- [x] Tested with article: https://addyo.substack.com/p/the-ai-native-software-engineer
- [x] Verified all 46 segments now display in scrollable sidebar
- [x] Confirmed responsive behavior on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)